### PR TITLE
Fix issue when no date column. 

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,5 +30,4 @@ Imports:
     emo,
     bindrcpp
 Remotes:
-  jeroen/curl,
   hadley/emo

--- a/R/utils.R
+++ b/R/utils.R
@@ -28,15 +28,17 @@ data_table <- function(data, options = list(), ..., filter = "top", style = "def
       list(targets = "_all", orderSequence = c("desc", "asc"))))
 
   options <- modifyList(options, default_opts)
-  datatable(data,
+  new_data <- datatable(data,
     ...,
     options = options,
     filter = filter,
     style = style,
     autoHideNavigation = autoHideNavigation,
     rownames = rownames,
-    escape = escape) %>%
-  formatDate(which(map_lgl(data, inherits, "POSIXct")), "toLocaleString")
+    escape = escape)
+  if (any(date_cols <- which(map_lgl(data, inherits, "POSIXct"))))
+    new_data <- formatDate(new_data, date_cols, "toLocaleString")
+  new_data
 }
 
 #' Plot a sparkline table


### PR DESCRIPTION
This will fix the error I have locally and on Connect

```
Error in mapply(FUN = f, ..., SIMPLIFY = FALSE) :
09/17 10:26:28.040 (GMT)
zero-length inputs cannot be mixed with those of non-zero length
09/17 10:26:28.040 (GMT)
Calls: local ... formatColumns -> append -> colFormatter -> Map -> mapply
````